### PR TITLE
Allow custom Daemonset upgrade strategy

### DIFF
--- a/cedana-helm/templates/host-binary-daemon-service.yaml
+++ b/cedana-helm/templates/host-binary-daemon-service.yaml
@@ -18,6 +18,11 @@ kind: DaemonSet
 metadata:
   name: cedana-daemon
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.daemonHelper.updateStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.daemonHelper.updateStrategy.maxUnavailable }}
   selector:
     matchLabels:
       app: binary-app

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -6,6 +6,9 @@ daemonHelper:
     repository: cedana/cedana-helper
     tag: latest
     imagePullPolicy: IfNotPresent
+  updateStrategy:
+    maxSurge: 100%
+    maxUnavailable: 0
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Orignal strategy and the time it takes to make the daemon to be ready is too long for helm when the cluster have many nodes.
