### PR TITLE
update:  helm chart consistency & general improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,33 @@ helm install cedana ./cedana-helm-charts/cedana-helm --create-namespace -n cedan
 # alternatively, you can use the oci repo
 helm install cedana oci://registry-1.docker.io/cedana/cedana-helm --create-namespace -n cedanacontroller-system
 ```
+
+### Usage
+
+Port-forward manager,
+
+```bash
+# port-forward manager service to access the api
+kubectl port-forwarding -n cedanacontroller-system service/cedana-manager-service 1324:1324
+```
+
+List containers we can attempt to checkpoint/restore,
+
+```bash
+# list containers in default namespace
+# requires provide: $RUNC_ROOT
+curl -X GET localhost:1324/list/default -D "{\"root\": \"$RUNC_ROOT\"}"
+```
+
+### Security
+
+```
+[!NOTE]
+If you want to use our tools, but have specific security requirements reach out and let us know
+about it.
+```
+
+- Daemonset requires privilege escalation for daemon container, and it updates the host directly with
+  required dependencies and our cedana-daemon application.
+
+- Currently our controller requires access to all pods to be able to list, checkpoint and restore them.

--- a/cedana-helm/templates/host-daemonset-service.yaml
+++ b/cedana-helm/templates/host-daemonset-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cedana-daemon-grpc-service
+spec:
+  selector:
+    app: binary-app
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 31000
+  type: NodePort

--- a/cedana-helm/templates/host-daemonset-service.yaml
+++ b/cedana-helm/templates/host-daemonset-service.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cedana-daemon-grpc-service
+  labels:
+  {{- include "cedana-helm.labels" . | nindent 4 }}
+  {{- with .Values.daemonHelper.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: binary-app

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -2,7 +2,13 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: cedana-daemon
+  name: {{ include "cedana-helm.fullname" . }}-daemon
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
+    control-plane: controller-manager
+  {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -33,6 +39,10 @@ spec:
               readOnly: false
           command: ["/bin/sh", "-c"]
           args: ["cedana k8s-helper --setup-host true && sleep infinity"]
+          ports:
+            - name: grpc
+              containerPort: 8080
+              protocol: TCP
           livenessProbe:
             grpc:
               port: 8080

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -1,18 +1,4 @@
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: cedana-daemon-grpc-service
-spec:
-  selector:
-    app: binary-app
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 8080
-      nodePort: 31000
-  type: NodePort
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -40,7 +26,6 @@ spec:
           imagePullPolicy: {{ .Values.daemonHelper.image.imagePullPolicy }}
           securityContext:
             privileged: true
-            # TODO(swarnimarun): check if this would ever be useful
             allowPrivilegeEscalation: true
           volumeMounts:
             - name: host-volume

--- a/cedana-helm/templates/leader-election-rbac.yaml
+++ b/cedana-helm/templates/leader-election-rbac.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-leader-election-role
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -46,8 +46,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-leader-election-rolebinding
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cedana-helm/templates/manager-deployment.yaml
+++ b/cedana-helm/templates/manager-deployment.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-controller-manager
   labels:
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
     control-plane: controller-manager
   {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: cedana-operator-controller-manager
+        app: cedana-manager
         control-plane: controller-manager
       {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
     spec:

--- a/cedana-helm/templates/manager-deployment.yaml
+++ b/cedana-helm/templates/manager-deployment.yaml
@@ -9,8 +9,10 @@ metadata:
     control-plane: controller-manager
   {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
-  # fixed at 1 replica per cluster
-  replicas: 1
+  {{- if not .Values.controllerManager.autoscaling.enabled }}
+  replicas: {{ .Values.controllerManager.autoscaling.replicaCount }}
+  revisionHistoryLimit: {{ .Values.controllerManager.autoscaling.deploymentRevisionHistoryLimit | default 10 }}
+  {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -38,7 +40,6 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-
         ports:
         - containerPort: 8443
           name: https

--- a/cedana-helm/templates/manager-rbac.yaml
+++ b/cedana-helm/templates/manager-rbac.yaml
@@ -51,8 +51,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-manager-rolebinding
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cedana-helm/templates/manager-service.yaml
+++ b/cedana-helm/templates/manager-service.yaml
@@ -2,10 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cedana-manager-service
+  labels:
+  {{- include "cedana-helm.labels" . | nindent 4 }}
+  {{- with .Values.controllerManager.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: cedana-manager
   ports:
-    - protocol: TCP
-      port: 1324
-      targetPort: 1324
+	{{- .Values.controllerManager.service.ports | toYaml | nindent 2 }}

--- a/cedana-helm/templates/manager-service.yaml
+++ b/cedana-helm/templates/manager-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cedana-manager-service
+spec:
+  selector:
+    app: cedana-manager
+  ports:
+    - protocol: TCP
+      port: 1324
+      targetPort: 1324

--- a/cedana-helm/templates/metrics-reader-rbac.yaml
+++ b/cedana-helm/templates/metrics-reader-rbac.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-metrics-reader
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 rules:
 - nonResourceURLs:

--- a/cedana-helm/templates/metrics-service.yaml
+++ b/cedana-helm/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cedana-helm.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "cedana-helm.fullname" . }}-controller-metrics-service
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: cedana-helm

--- a/cedana-helm/templates/metrics-service.yaml
+++ b/cedana-helm/templates/metrics-service.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-controller-manager-metrics-service
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
     control-plane: controller-manager
   {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:

--- a/cedana-helm/templates/proxy-rbac.yaml
+++ b/cedana-helm/templates/proxy-rbac.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-proxy-role
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -27,8 +27,8 @@ metadata:
   name: {{ include "cedana-helm.fullname" . }}-proxy-rolebinding
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
   {{- include "cedana-helm.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cedana-helm/templates/proxy-rbac.yaml
+++ b/cedana-helm/templates/proxy-rbac.yaml
@@ -38,3 +38,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "cedana-helm.serviceAccountName" . }}'
   namespace: '{{ .Release.Namespace }}'
+

--- a/cedana-helm/templates/serviceaccount.yaml
+++ b/cedana-helm/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "cedana-helm.serviceAccountName" . }}
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: cedana-operator
-    app.kubernetes.io/part-of: cedana-operator
+    app.kubernetes.io/created-by: cedana-helm
+    app.kubernetes.io/part-of: cedana-helm
     {{- include "cedana-helm.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -2,13 +2,15 @@ cedanaConfig:
   signozApiKey: randomkey
 
 daemonHelper:
+  service:
+    annotations: {}
   image:
     repository: cedana/cedana-helper
     tag: latest
     imagePullPolicy: IfNotPresent
   updateStrategy:
     maxSurge: 25%
-    maxUnavailable: 25%
+    maxUnavailable: 0
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -22,13 +24,24 @@ serviceAccount:
   name: "cedana-controller-manager"
 
 controllerManager:
-  podAnnotations: {}
+  autoscaling:
+    enabled: false
+    replicaCount: 1
+    deploymentRevisionHistoryLimit: 10
+  service:
+    annotations: {}
+    ports:
+      - protocol: TCP
+        port: 1324
+        targetPort: 1324
   manager:
+    podAnnotations: {}
     args:
       - --health-probe-bind-address=:8081
       - --metrics-bind-address=127.0.0.1:8080
       - --leader-elect
     containerSecurityContext:
+      # controller doesn't require any privileges
       allowPrivilegeEscalation: false
       capabilities:
         drop:
@@ -38,22 +51,26 @@ controllerManager:
       tag: latest
       imagePullPolicy: IfNotPresent
     resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
+      # empty to ensure minimal resource
+      # usage on demo/test deployments
+      # uncomment or add custom resource
+      # limits:
+      #   cpu: 500m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 64Mi
   rbac:
     resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  serviceAccount:
-    annotations: {}
+      # empty to ensure minimal resource
+      # usage on demo/test deployments
+      # uncomment or add custom resource
+      # limits:
+      #   cpu: 500m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 64Mi
 
 kubernetesClusterDomain: cluster.local
 


### PR DESCRIPTION
- Fix naming and consistency in line with Everton's PRs.
	- Splitting service and daemons
	- Adding service for manager.
	- Making autoscaling configurable. (controller safely handle replicas)
	- Make most annotations customizable.
	- Don't provide resource limits for rbac and manager to ensure leaner test deployments.

- Add more fields and configuration options to values.yaml.

- Update the README with usage and security info.

- Update defaults for maxSurge, set maxUnavailable