### PR TITLE
feat: support upgrade and restart option & remove prestop hook

### DIFF
--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -58,10 +58,6 @@ spec:
               port: 8080
             initialDelaySeconds: 100
             periodSeconds: 20
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "cedana k8s-helper destroy"]
           env:
             - name: SIGNOZ_ACCESS_TOKEN
               valueFrom:

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -38,7 +38,11 @@ spec:
               mountPath: /host
               readOnly: false
           command: ["/bin/sh", "-c"]
+          {{ if .Values.daemonHelper.upgradeAndRestart }}
+          args: ["cedana k8s-helper --restart true && sleep infinity"]
+          {{ else }}
           args: ["cedana k8s-helper --setup-host true && sleep infinity"]
+          {{ end }}
           ports:
             - name: grpc
               containerPort: 8080
@@ -46,17 +50,15 @@ spec:
           livenessProbe:
             grpc:
               port: 8080
-            initialDelaySeconds: 200
             periodSeconds: 20
           startupProbe:
             grpc:
               port: 8080
-            initialDelaySeconds: 100
-            periodSeconds: 20
+            initialDelaySeconds: 1
+            periodSeconds: 2
           readinessProbe:
             grpc:
               port: 8080
-            initialDelaySeconds: 100
             periodSeconds: 20
           env:
             - name: SIGNOZ_ACCESS_TOKEN

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -2,6 +2,7 @@ cedanaConfig:
   signozApiKey: randomkey
 
 daemonHelper:
+  upgradeAndRestart: false
   service:
     annotations: {}
   image:
@@ -9,8 +10,8 @@ daemonHelper:
     tag: latest
     imagePullPolicy: IfNotPresent
   updateStrategy:
-    maxSurge: 25%
-    maxUnavailable: 0
+    maxSurge: 0
+    maxUnavailable: 1
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
### Describe your changes

Don't remove daemon on helm uninstall/update.

To uninstall cedana daemon from host images, we have to now use a separate yaml file.

Or do it manually.

We add, `daemonHelper.upgradeAndRestart` option to avoid setup on upgrade attempts.
