### PR TITLE
Improve labels and stop repeating names

### DIFF
--- a/cedana-helm/templates/host-daemonset-service.yaml
+++ b/cedana-helm/templates/host-daemonset-service.yaml
@@ -1,16 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: cedana-daemon-grpc-service
+  name: {{ include "cedana-helm.fullname" . }}-helper
   labels:
-  {{- include "cedana-helm.labels" . | nindent 4 }}
+    {{- include "cedana-helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: helper
   {{- with .Values.daemonHelper.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   selector:
-    app: binary-app
+    {{- include "cedana-helm.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: helper
   ports:
     - protocol: TCP
       port: 8080

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -2,13 +2,12 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "cedana-helm.fullname" . }}-daemon
+  name: {{ include "cedana-helm.fullname" . }}
   labels:
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/component: helper
     app.kubernetes.io/created-by: cedana-helm
     app.kubernetes.io/part-of: cedana-helm
-    control-plane: controller-manager
-  {{- include "cedana-helm.labels" . | nindent 4 }}
+    {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -17,11 +16,14 @@ spec:
       maxUnavailable: {{ .Values.daemonHelper.updateStrategy.maxUnavailable }}
   selector:
     matchLabels:
-      app: binary-app
+      app.kubernetes.io/component: helper
+      {{- include "cedana-helm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: binary-app
+        app.kubernetes.io/component: helper
+        {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
     spec:
       hostPID: true
       hostNetwork: true

--- a/cedana-helm/templates/manager-deployment.yaml
+++ b/cedana-helm/templates/manager-deployment.yaml
@@ -1,12 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cedana-helm.fullname" . }}-controller-manager
+  name: {{ include "cedana-helm.fullname" . }}-manager
   labels:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: cedana-helm
     app.kubernetes.io/part-of: cedana-helm
-    control-plane: controller-manager
   {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.controllerManager.autoscaling.enabled }}
@@ -15,8 +14,8 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      control-plane: controller-manager
-    {{- include "cedana-helm.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: manager
+      {{- include "cedana-helm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -25,9 +24,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: cedana-manager
-        control-plane: controller-manager
-      {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: manager
+        {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
     spec:
       containers:
       - name: kube-rbac-proxy

--- a/cedana-helm/templates/manager-service.yaml
+++ b/cedana-helm/templates/manager-service.yaml
@@ -1,15 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: cedana-manager-service
+  name: {{ include "cedana-helm.fullname" . }}-manager
   labels:
-  {{- include "cedana-helm.labels" . | nindent 4 }}
+    {{- include "cedana-helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
   {{- with .Values.controllerManager.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   selector:
-    app: cedana-manager
+    {{- include "cedana-helm.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
   ports:
 	{{- .Values.controllerManager.service.ports | toYaml | nindent 2 }}

--- a/cedana-helm/templates/metrics-service.yaml
+++ b/cedana-helm/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cedana-helm.fullname" . }}-controller-metrics-service
+  name: {{ include "cedana-helm.fullname" . }}-controller-metrics
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: cedana-helm

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 cedanaConfig:
   signozApiKey: randomkey
 


### PR DESCRIPTION
- Improve label usae to follow k8s standards (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
- Remove resource type repetition in name (don't call a `service` of `cedana-service`, use `cedana` instead).
