### PR TITLE
fix: add controller ns as environ to manager deployment

### DIFF
--- a/cedana-helm/templates/host-daemonset-service.yaml
+++ b/cedana-helm/templates/host-daemonset-service.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     {{- include "cedana-helm.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: helper
+    cedana.ai/app: helper
   ports:
     - protocol: TCP
       port: 8080

--- a/cedana-helm/templates/host-daemonset-service.yaml
+++ b/cedana-helm/templates/host-daemonset-service.yaml
@@ -12,7 +12,6 @@ metadata:
 spec:
   selector:
     {{- include "cedana-helm.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: helper
     cedana.ai/app: helper
   ports:
     - protocol: TCP

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -21,8 +21,8 @@ spec:
   template:
     metadata:
       labels:
-        app: binary-app
         app.kubernetes.io/component: helper
+        cedana.ai/app: helper
         {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
     spec:
       hostPID: true

--- a/cedana-helm/templates/manager-deployment.yaml
+++ b/cedana-helm/templates/manager-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        - name: CONTROLLER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.imagePullPolicy }}
         livenessProbe:


### PR DESCRIPTION
## Describe your changes
- Pass cedana namespace as an environ to manager deployment
- Hard code a cedana label with our domain for locating cedana daemons

<!-- Please explain the changes you made here. -->

## Caveats (if any)
- I don't know if this is correct :D

<!-- Please explain what might be possible caveats in the PR (if any). -->
<!-- Eg, makes certain feature slower, can be brittle and break easily with misconfiguration, etc. -->

## Issue Ticket ID
n/a

<!-- For example, "Fixes CED-001" -->
<!-- linear-bot will auto link the issue ticket. -->

### Checklist before requesting a review

- [ ] Code compiles correctly.
- [x] Self-review to ensure, the PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Created tests which fail without the change (if possible).
- [ ] Rest of the tests are passing.
- [x] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.
- [ ] Extended the README / documentation, if changes have resulted in it being out of date?

The breaking change is that the controller has to be updated to pull from env