### PR TITLE
fix: daemon pod dns policy

### DIFF
--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
     spec:
       hostPID: true
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostIPC: true
       containers:
         - name: binary-container


### PR DESCRIPTION
### Describe your changes
Cluster dns is unavailable without the above dns policy changes. 

### Motivation
Required to use cluster dns for easier networking between daemon, controller and other services.

### Caveats (if any)

Note: this config doesn't work on windows even with wsl2, but cedana doesn't support windows so it's a non-issue for us. 

