### PR TITLE
feat: support custom addr ports and protocol config

### DIFF
--- a/cedana-helm/templates/configmap.yaml
+++ b/cedana-helm/templates/configmap.yaml
@@ -11,6 +11,8 @@ metadata:
 data:
   cluster-name: "{{ required "Please provide --set config.clusterName=<cluster-name>" .Values.config.clusterName }}"
   url: "{{ required "Please provide --set config.url=<cedana-url>" .Values.config.url }}"
+  address-with-port: "{{ required "Please provide --set config.addressWithPort=<daemon-address>" .Values.config.addressWithPort }}"
+  protocol: "{{ required "Please provide --set config.protocol=<daemon-protocol>" .Values.config.protocol }}"
   sqs-queue-url: "{{ .Values.config.sqsQueueUrl }}"
   checkpoint-dir: "{{ .Values.config.checkpointDir }}"
   checkpoint-streams: "{{ .Values.config.checkpointStreams }}"

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -73,9 +73,15 @@ spec:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: url
             - name: CEDANA_ADDRESS
-              value: 0.0.0.0:8080
+              valueFrom: 
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: address-with-port
             - name: CEDANA_PROTOCOL
-              value: tcp
+              valueFrom: 
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: protocol
             - name: CEDANA_CHECKPOINT_DIR
               valueFrom:
                 configMapKeyRef:

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -11,6 +11,17 @@ config:
   clusterName: ""
   sqsQueueUrl: ""
 
+  # Specify the address and port to bind the daemon on
+  # 
+  # Address has to be 0.0.0.0 for the service to be externally addressable,
+  # if you don't want it to be feel free to update, it ideally won't affect stability
+  # 
+  # Default: 8080 (other addresses might not be supported properly, update with caution)
+  addressWithPort: 0.0.0.0:8080
+  # Specify the protocol to use for daemon service
+  # Default: tcp (other protocols might not be supported properly, update with caution)
+  protocol: tcp
+
   # Specify path to directory for storing checkpoints.
   # - `cedana://<path>` for Cedana-managed global storage (recommended)
   # - `s3://<bucket>/<path>` for your S3 storage


### PR DESCRIPTION
### **PR Summary**

* Added configurable `addressWithPort` and `protocol` fields to `values.yaml` with defaults and documentation.
* Updated `configmap.yaml` to include `address-with-port` and `protocol` as required parameters.
* Modified `host-daemonset.yaml` to source `CEDANA_ADDRESS` and `CEDANA_PROTOCOL` from the ConfigMap instead of hardcoded values.
