### PR TITLE
CED-1485: Fix helm upgrade not triggered by config changes

### DIFF
--- a/cedana-helm/templates/_checksum-configmap.tpl
+++ b/cedana-helm/templates/_checksum-configmap.tpl
@@ -1,0 +1,51 @@
+{{- define "cedana-helm.configmap.checksum" -}}
+{{- $config := dict -}}
+
+{{- /* Direct values from .Values.config */ -}}
+{{- $configKeysFromValuesConfig := list
+  "clusterId"
+  "url"
+  "address"
+  "protocol"
+  "sqsQueueUrl"
+  "checkpointDir"
+  "checkpointStreams"
+  "checkpointCompression"
+  "gpuPoolSize"
+  "gpuFreezeType"
+  "gpuShmSize"
+  "gpuLdLibPath"
+  "pluginsBuilds"
+  "pluginsNativeVersion"
+  "pluginsCriuVersion"
+  "pluginsRuntimeShimVersion"
+  "pluginsGpuVersion"
+  "pluginsStreamerVersion"
+  "metrics"
+  "profiling"
+  "logLevel"
+  "awsAccessKeyId"
+  "awsRegion"
+-}}
+{{- range $key := $configKeysFromValuesConfig -}}
+  {{- if hasKey $.Values.config $key -}}
+    {{- $_ := set $config $key (get $.Values.config $key) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Values from .Values.shmConfig */ -}}
+{{- if hasKey $.Values "shmConfig" -}}
+  {{- if hasKey $.Values.shmConfig "enabled" -}}
+    {{- $_ := set $config "shm-config-enabled" (get $.Values.shmConfig "enabled") -}}
+  {{- end -}}
+  {{- if hasKey $.Values.shmConfig "size" -}}
+    {{- $_ := set $config "shm-config-size" (get $.Values.shmConfig "size") -}}
+  {{- end -}}
+  {{- if hasKey $.Values.shmConfig "minSize" -}}
+    {{- $_ := set $config "shm-config-min-size" (get $.Values.shmConfig "minSize") -}}
+  {{- end -}}
+{{- end -}}
+
+{{- sha256sum (toJson $config) -}}
+{{- end -}}
+

--- a/cedana-helm/templates/host-daemonset.yaml
+++ b/cedana-helm/templates/host-daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: helper
         {{- include "cedana-helm.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include "cedana-helm.configmap.checksum" . | sha256sum }}
     spec:
       hostPID: true
       hostNetwork: true

--- a/cedana-helm/templates/manager-deployment.yaml
+++ b/cedana-helm/templates/manager-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: cedana-helm
     app.kubernetes.io/part-of: cedana-helm
-  {{- include "cedana-helm.labels" . | nindent 4 }}
+    {{- include "cedana-helm.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.controllerManager.autoscaling.enabled }}
   replicas: {{ .Values.controllerManager.autoscaling.replicaCount }}
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include "cedana-helm.configmap.checksum" . | sha256sum }}
         kubectl.kubernetes.io/default-container: manager
       {{- with .Values.controllerManager.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -61,6 +61,13 @@ config:
   # Uncomment, to use custom pre-existing secret
   # preExistingSecret: cedana-secret-user
 
+# Optional configuration to increase /dev/shm size on nodes
+# This is useful for workloads that require large shared memory
+shmConfig:
+  enabled: false # Set to true to enable /dev/shm size increase
+  size: "10G" # Size to set for /dev/shm (e.g., "10G", "20G")
+  minSize: "10G" # Minimum size to trigger remount (e.g., "10G", "20G")
+
 daemonHelper:
   upgradeAndRestart: false
   service:
@@ -157,13 +164,6 @@ controllerManager:
     #               - "cedana-manager"
 
 kubernetesClusterDomain: cluster.local
-
-# Optional configuration to increase /dev/shm size on nodes
-# This is useful for workloads that require large shared memory
-shmConfig:
-  enabled: false # Set to true to enable /dev/shm size increase
-  size: "10G" # Size to set for /dev/shm (e.g., "10G", "20G")
-  minSize: "10G" # Minimum size to trigger remount (e.g., "10G", "20G")
 
 metricsService:
   ports:


### PR DESCRIPTION
## Describe your changes
Helm upgrade would only trigger helper and controller restart if the repo & tag were being updated, which is not the case for every helm update we release.

Due to this, users would have to uninstall and reinstall the chart to get the latest changes.

This fix ensures that any change to the `config` and `shmConfig` in values.yaml will trigger a full upgrade.

## Checklist before requesting a review

- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.