### PR TITLE
CED-1493: Downgrade shim version in latest helm chart

### DIFF
--- a/cedana-helm/Chart.yaml
+++ b/cedana-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cedana-helm
 description: Helm chart for Cedana k8s system
 type: application
-version: 0.5.1
+version: 0.5.2
 # The appVersion is the version of the Cedana API this chart
 # should best work with.
 appVersion: 2.0.0.6-hotfix.2

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -46,7 +46,7 @@ config:
   pluginsBuilds: "release"
   pluginsNativeVersion: "latest"
   pluginsCriuVersion: "v4.1.1-cedana.00"
-  pluginsRuntimeShimVersion: "v0.6.2"
+  pluginsRuntimeShimVersion: "v0.6.1"
   pluginsGpuVersion: "v0.5.9"
   pluginsStreamerVersion: "v0.0.8"
 


### PR DESCRIPTION
## Describe your changes
Latest shim appears to be incompatible with older containerd versions despite being the same v2-compliant shim.

## Checklist before requesting a review

- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.