### PR TITLE
CED-1894: Spruce up metrics install for Cedana 

### DIFF
--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -51,7 +51,7 @@ config:
   pluginsNativeVersion: latest
   pluginsCriuVersion: 7/merge
   pluginsContainerdRuntimeVersion: v0.7.1
-  pluginsGpuVersion: v0.7.0
+  pluginsGpuVersion: feat/ced-1839-perf-llamafactory
   pluginsStreamerVersion: v0.0.8
 
   profiling: true

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -82,8 +82,8 @@ daemonHelper:
   service:
     annotations: {}
   image:
-    repository: cedana/cedana-helper
-    tag: v0.9.283
+    repository: cedana/cedana-helper-test
+    tag: 7a232b7db81752e27c6de9588031104acc038f85
     digest: # ignores tag if set
     imagePullPolicy: IfNotPresent
   updateStrategy:

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -51,7 +51,7 @@ config:
   pluginsNativeVersion: latest
   pluginsCriuVersion: 7/merge
   pluginsContainerdRuntimeVersion: v0.7.1
-  pluginsGpuVersion: feat/ced-1839-perf-llamafactory
+  pluginsGpuVersion: v0.7.0
   pluginsStreamerVersion: v0.0.8
 
   profiling: true
@@ -82,8 +82,8 @@ daemonHelper:
   service:
     annotations: {}
   image:
-    repository: cedana/cedana-helper-test
-    tag: 7a232b7db81752e27c6de9588031104acc038f85
+    repository: cedana/cedana-helper
+    tag: v0.9.283 
     digest: # ignores tag if set
     imagePullPolicy: IfNotPresent
   updateStrategy:

--- a/metrics/event-exporter/deploy.yaml
+++ b/metrics/event-exporter/deploy.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cedana-monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-event-exporter
+  namespace: cedana-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-event-exporter
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-event-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-event-exporter
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-event-exporter
+    namespace: cedana-monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-event-exporter-config
+  namespace: cedana-monitoring
+data:
+  config.yaml: |
+    logLevel: info
+    logFormat: json
+    metricsNamePrefix: event_exporter_
+    receivers:
+      - name: "dump"
+        stdout:
+          layout:
+            message: "{{ .Message }}"
+            reason: "{{ .Reason }}"
+            type: "{{ .Type }}"
+            count: "{{ .Count }}"
+            kind: "{{ .InvolvedObject.Kind }}"
+            name: "{{ .InvolvedObject.Name }}"
+            namespace: "{{ .Namespace }}"
+            component: "{{ .Source.Component }}"
+            host: "{{ .Source.Host }}"
+            firstTimestamp: "{{ .FirstTimestamp }}"
+            lastTimestamp: "{{ .LastTimestamp }}"
+    route:
+      routes:
+        - match:
+            - receiver: "dump"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-event-exporter
+  namespace: cedana-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-event-exporter
+  template:
+    metadata:
+      labels:
+        app: kubernetes-event-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2112"
+    spec:
+      serviceAccountName: kubernetes-event-exporter
+      containers:
+        - name: event-exporter
+          image: ghcr.io/resmoio/kubernetes-event-exporter:v1.7
+          args:
+            - -conf=/data/config.yaml
+          ports:
+            - containerPort: 2112
+              name: metrics
+          volumeMounts:
+            - name: config
+              mountPath: /data
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      volumes:
+        - name: config
+          configMap:
+            name: kubernetes-event-exporter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-event-exporter
+  namespace: cedana-monitoring
+  labels:
+    app: kubernetes-event-exporter
+spec:
+  selector:
+    app: kubernetes-event-exporter
+  ports:
+    - port: 2112
+      targetPort: 2112
+      name: metrics

--- a/metrics/event-exporter/values.yml
+++ b/metrics/event-exporter/values.yml
@@ -1,0 +1,61 @@
+# Kubernetes Event Exporter values for Cedana monitoring
+# Bitnami chart: https://artifacthub.io/packages/helm/bitnami/kubernetes-event-exporter
+
+# Enable metrics endpoint for Vector/Prometheus scraping
+metrics:
+  enabled: true
+  service:
+    ports:
+      http: 2112
+
+# Configure which events to capture and how to export them
+config:
+  logLevel: info
+  logFormat: json
+  receivers:
+    - name: "dump"
+      file:
+        path: "/dev/stdout"
+        layout:
+          message: "{{ .Message }}"
+          reason: "{{ .Reason }}"
+          type: "{{ .Type }}"
+          count: "{{ .Count }}"
+          kind: "{{ .InvolvedObject.Kind }}"
+          name: "{{ .InvolvedObject.Name }}"
+          namespace: "{{ .Namespace }}"
+          component: "{{ .Source.Component }}"
+          host: "{{ .Source.Host }}"
+          firstTimestamp: "{{ .FirstTimestamp }}"
+          lastTimestamp: "{{ .LastTimestamp }}"
+  route:
+    routes:
+      - match:
+          - receiver: "dump"
+
+# RBAC for reading events
+rbac:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["get", "watch", "list"]
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]
+    - apiGroups: ["batch"]
+      resources: ["jobs"]
+      verbs: ["get", "list"]
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: true
+
+# Resource limits
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi

--- a/metrics/prometheus/values.yml
+++ b/metrics/prometheus/values.yml
@@ -834,430 +834,30 @@ serverFiles:
   ## DEPRECATED DEFAULT VALUE, unless explicitly naming your files, please use recording_rules.yml
   rules: {}
 
-  prometheus.yml:
-    rule_files:
-      - /etc/config/recording_rules.yml
-      - /etc/config/alerting_rules.yml
-    ## Below two files are DEPRECATED will be removed from this default values file
-      - /etc/config/rules
-      - /etc/config/alerts
-
-    scrape_configs:
-      - job_name: prometheus
-        static_configs:
-          - targets:
-            - localhost:9090
-
-      # A scrape configuration for running Prometheus on a Kubernetes cluster.
-      # This uses separate scrape configs for cluster components (i.e. API server, node)
-      # and services to allow each to use different authentication configs.
-      #
-      # Kubernetes labels will be added as Prometheus labels on metrics via the
-      # `labelmap` relabeling action.
-
-      # Scrape config for API servers.
-      #
-      # Kubernetes exposes API servers as endpoints to the default/kubernetes
-      # service so this uses `endpoints` role and uses relabelling to only keep
-      # the endpoints associated with the default/kubernetes service using the
-      # default named port `https`. This works for single API server deployments as
-      # well as HA API server deployments.
-      - job_name: 'kubernetes-apiservers'
-
-        kubernetes_sd_configs:
-          - role: endpoints
-
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
-        scheme: https
-
-        # This TLS & bearer token file config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-        # Keep only the default/kubernetes service endpoints for the https port. This
-        # will add targets for each API server which Kubernetes adds an endpoint to
-        # the default/kubernetes service.
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-            action: keep
-            regex: default;kubernetes;https
-
-      - job_name: 'kubernetes-nodes'
-
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
-        scheme: https
-
-        # This TLS & bearer token file config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-        kubernetes_sd_configs:
-          - role: node
-
-        relabel_configs:
-          - action: labelmap
-            regex: __meta_kubernetes_node_label_(.+)
-          - target_label: __address__
-            replacement: kubernetes.default.svc:443
-          - source_labels: [__meta_kubernetes_node_name]
-            regex: (.+)
-            target_label: __metrics_path__
-            replacement: /api/v1/nodes/$1/proxy/metrics
-
-
-      - job_name: 'kubernetes-nodes-cadvisor'
-
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
-        scheme: https
-
-        # This TLS & bearer token file config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-        kubernetes_sd_configs:
-          - role: node
-
-        # This configuration will work only on kubelet 1.7.3+
-        # As the scrape endpoints for cAdvisor have changed
-        # if you are using older version you need to change the replacement to
-        # replacement: /api/v1/nodes/$1:4194/proxy/metrics
-        # more info here https://github.com/coreos/prometheus-operator/issues/633
-        relabel_configs:
-          - action: labelmap
-            regex: __meta_kubernetes_node_label_(.+)
-          - target_label: __address__
-            replacement: kubernetes.default.svc:443
-          - source_labels: [__meta_kubernetes_node_name]
-            regex: (.+)
-            target_label: __metrics_path__
-            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-
-        # Metric relabel configs to apply to samples before ingestion.
-        # [Metric Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)
-        # metric_relabel_configs:
-        # - action: labeldrop
-        #   regex: (kubernetes_io_hostname|failure_domain_beta_kubernetes_io_region|beta_kubernetes_io_os|beta_kubernetes_io_arch|beta_kubernetes_io_instance_type|failure_domain_beta_kubernetes_io_zone)
-
-      # Scrape config for service endpoints.
-      #
-      # The relabeling allows the actual service scrape endpoint to be configured
-      # via the following annotations:
-      #
-      # * `prometheus.io/scrape`: Only scrape services that have a value of
-      # `true`, except if `prometheus.io/scrape-slow` is set to `true` as well.
-      # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-      # to set this to `https` & most likely set the `tls_config` of the scrape config.
-      # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-      # * `prometheus.io/port`: If the metrics are exposed on a different port to the
-      # service then set this appropriately.
-      # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
-      # then you can set any parameter
-      - job_name: 'kubernetes-service-endpoints'
-        honor_labels: true
-
-        kubernetes_sd_configs:
-          - role: endpoints
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
-            action: drop
-            regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-            action: replace
-            target_label: __scheme__
-            regex: (https?)
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-            action: replace
-            target_label: __address__
-            regex: (.+?)(?::\d+)?;(\d+)
-            replacement: $1:$2
-          - action: labelmap
-            regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
-            replacement: __param_$1
-          - action: labelmap
-            regex: __meta_kubernetes_service_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_service_name]
-            action: replace
-            target_label: service
-          - source_labels: [__meta_kubernetes_pod_node_name]
-            action: replace
-            target_label: node
-
-      # Scrape config for slow service endpoints; same as above, but with a larger
-      # timeout and a larger interval
-      #
-      # The relabeling allows the actual service scrape endpoint to be configured
-      # via the following annotations:
-      #
-      # * `prometheus.io/scrape-slow`: Only scrape services that have a value of `true`
-      # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-      # to set this to `https` & most likely set the `tls_config` of the scrape config.
-      # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-      # * `prometheus.io/port`: If the metrics are exposed on a different port to the
-      # service then set this appropriately.
-      # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
-      # then you can set any parameter
-      - job_name: 'kubernetes-service-endpoints-slow'
-        honor_labels: true
-
-        scrape_interval: 5m
-        scrape_timeout: 30s
-
-        kubernetes_sd_configs:
-          - role: endpoints
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-            action: replace
-            target_label: __scheme__
-            regex: (https?)
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-            action: replace
-            target_label: __address__
-            regex: (.+?)(?::\d+)?;(\d+)
-            replacement: $1:$2
-          - action: labelmap
-            regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
-            replacement: __param_$1
-          - action: labelmap
-            regex: __meta_kubernetes_service_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_service_name]
-            action: replace
-            target_label: service
-          - source_labels: [__meta_kubernetes_pod_node_name]
-            action: replace
-            target_label: node
-
-      - job_name: 'prometheus-pushgateway'
-        honor_labels: true
-
-        kubernetes_sd_configs:
-          - role: service
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
-            action: keep
-            regex: pushgateway
-
-      # Example scrape config for probing services via the Blackbox Exporter.
-      #
-      # The relabeling allows the actual service scrape endpoint to be configured
-      # via the following annotations:
-      #
-      # * `prometheus.io/probe`: Only probe services that have a value of `true`
-      - job_name: 'kubernetes-services'
-        honor_labels: true
-
-        metrics_path: /probe
-        params:
-          module: [http_2xx]
-
-        kubernetes_sd_configs:
-          - role: service
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
-            action: keep
-            regex: true
-          - source_labels: [__address__]
-            target_label: __param_target
-          - target_label: __address__
-            replacement: blackbox
-          - source_labels: [__param_target]
-            target_label: instance
-          - action: labelmap
-            regex: __meta_kubernetes_service_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_service_name]
-            target_label: service
-
-      # Example scrape config for pods
-      #
-      # The relabeling allows the actual pod scrape endpoint to be configured via the
-      # following annotations:
-      #
-      # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`,
-      # except if `prometheus.io/scrape-slow` is set to `true` as well.
-      # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-      # to set this to `https` & most likely set the `tls_config` of the scrape config.
-      # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-      # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: 'kubernetes-pods'
-        honor_labels: true
-
-        kubernetes_sd_configs:
-          - role: pod
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
-            action: drop
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
-            action: replace
-            regex: (https?)
-            target_label: __scheme__
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
-            action: replace
-            regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-            replacement: '[$2]:$1'
-            target_label: __address__
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
-            action: replace
-            regex: (\d+);((([0-9]+?)(\.|$)){4})
-            replacement: $2:$1
-            target_label: __address__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
-            replacement: __param_$1
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: pod
-          - source_labels: [__meta_kubernetes_pod_phase]
-            regex: Pending|Succeeded|Failed|Completed
-            action: drop
-          - source_labels: [__meta_kubernetes_pod_node_name]
-            action: replace
-            target_label: node
-
-      # Example Scrape config for pods which should be scraped slower. An useful example
-      # would be stackriver-exporter which queries an API on every scrape of the pod
-      #
-      # The relabeling allows the actual pod scrape endpoint to be configured via the
-      # following annotations:
-      #
-      # * `prometheus.io/scrape-slow`: Only scrape pods that have a value of `true`
-      # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-      # to set this to `https` & most likely set the `tls_config` of the scrape config.
-      # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-      # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: 'kubernetes-pods-slow'
-        honor_labels: true
-
-        scrape_interval: 5m
-        scrape_timeout: 30s
-
-        kubernetes_sd_configs:
-          - role: pod
-
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
-            action: replace
-            regex: (https?)
-            target_label: __scheme__
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
-            action: replace
-            regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-            replacement: '[$2]:$1'
-            target_label: __address__
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
-            action: replace
-            regex: (\d+);((([0-9]+?)(\.|$)){4})
-            replacement: $2:$1
-            target_label: __address__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
-            replacement: __param_$1
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: namespace
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: pod
-          - source_labels: [__meta_kubernetes_pod_phase]
-            regex: Pending|Succeeded|Failed|Completed
-            action: drop
-          - source_labels: [__meta_kubernetes_pod_node_name]
-            action: replace
-            target_label: node
+  # Use the helm chart's default scrape configs - no custom prometheus.yml needed
+  # The chart provides all standard kubernetes scrape configs by default
 
 # adds additional scrape configs to prometheus.yml
 # must be a string so you have to add a | after extraScrapeConfigs:
 # example adds prometheus-blackbox-exporter scrape config
-extraScrapeConfigs: ""
+extraScrapeConfigs: |
+  - job_name: 'kubernetes-cadvisor'
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
   # - job_name: 'prometheus-blackbox-exporter'
   #   metrics_path: /probe
   #   params:
@@ -1290,15 +890,30 @@ networkPolicy:
 forceNamespace: ""
 
 # Extra manifests to deploy as an array
-extraManifests: []
-  # - |
-  #   apiVersion: v1
-  #   kind: ConfigMap
-  #   metadata:
-  #   labels:
-  #     name: prometheus-extra
-  #   data:
-  #     extra-data: "value"
+extraManifests:
+  # ClusterRole extension for nodes/proxy to enable cAdvisor scraping via API server
+  - |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: prometheus-server-cadvisor
+    rules:
+      - apiGroups: [""]
+        resources: ["nodes/proxy"]
+        verbs: ["get"]
+  - |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: prometheus-server-cadvisor
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: prometheus-server-cadvisor
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-server
+        namespace: cedana-monitoring
 
 # Configuration of subcharts defined in Chart.yaml
 

--- a/metrics/vector/values.yml
+++ b/metrics/vector/values.yml
@@ -367,9 +367,10 @@ customConfig:
       endpoints:
         - http://kubernetes-event-exporter.cedana-monitoring.svc.cluster.local:2112/metrics
       scrape_interval_secs: 30
-    kubernetes_logs:
-      type: kubernetes_logs
-      self_node_name: "${VECTOR_SELF_NODE_NAME}"
+    # DISABLED: kubernetes_logs - log forwarding disabled to avoid interfering with k9s/kubectl logs
+    # kubernetes_logs:
+    #   type: kubernetes_logs
+    #   self_node_name: "${VECTOR_SELF_NODE_NAME}"
 
   transforms:
     host_filter:
@@ -399,10 +400,48 @@ customConfig:
         - event-exporter
       source: |
         .tags.collector = "event-exporter"
+    # Filter kube-state-metrics to only include pod ownership info
+    # This captures Job, Deployment, StatefulSet, ReplicaSet, DaemonSet owners
+    kube_state_filter:
+      type: filter
+      inputs:
+        - kube-state-metrics
+      condition: |
+        .name == "kube_pod_owner" || .name == "kube_pod_info" || .name == "kube_job_owner"
+    kube_state_tag:
+      type: remap
+      inputs:
+        - kube_state_filter
+      source: |
+        .tags.collector = "kube-state-metrics"
+    # Filter DCGM GPU metrics - core metrics only
+    dcgm_filter:
+      type: filter
+      inputs:
+        - dcgm-exporter
+      condition: |
+        starts_with(string!(.name), "DCGM_FI_DEV_") || starts_with(string!(.name), "DCGM_FI_PROF_")
+    dcgm_tag:
+      type: remap
+      inputs:
+        - dcgm_filter
+      source: |
+        # Use Hostname from DCGM metrics (the actual GPU node), not Vector pod's node
+        .tags.host = if exists(.tags.Hostname) { .tags.Hostname } else { get_env_var!("SPEC_NODE_NAME") }
+        .tags.collector = "dcgm"
+    # Add reverse timestamp for newest-first S3 ordering
+    # S3Queue processes files lexicographically, so 9999999999 - unix_ts
+    # ensures newest files sort FIRST (smaller reverse_ts = newer data)
+    # NOTE: For metrics events, we must add to .tags map, not top-level
+    add_reverse_timestamp:
+      type: remap
+      inputs: [host_filter, cadvisor_tag, event_exporter_tag, kube_state_tag, dcgm_tag]
+      source: |
+        .tags.reverse_ts = to_string(9999999999 - to_unix_timestamp(now()))
   sinks:
     s3_sink:
       type: aws_s3
-      inputs: [host_filter, cadvisor_tag, event_exporter_tag]
+      inputs: [add_reverse_timestamp]
       bucket: "" # specify s3 bucket name
       region: "" # specify s3 bucket region
       compression: "none"
@@ -410,31 +449,36 @@ customConfig:
         codec: "json"
       batch:
         max_bytes: 10485760 # 10MB
-        timeout_secs: 60
-      key_prefix: "vector/data/date=%Y-%m-%d/hour=%H/minute=%M/"  # Will be overridden by --set at deployment
+        timeout_secs: 15  # Reduced from 60 for faster data availability
+      # Reverse timestamp prefix ensures newest data sorts FIRST lexicographically
+      # S3Queue with ordered mode will process newest files first
+      # Access tags.reverse_ts since metrics store custom fields in tags map
+      key_prefix: "vector/data/{{ tags.reverse_ts }}/"
       filename_time_format: "%s"
       filename_append_uuid: true
-    s3_logs_sink:
-      type: aws_s3
-      inputs: [kubernetes_logs]
-      bucket: "" # specify s3 bucket name
-      region: "" # specify s3 bucket region
-      compression: "gzip"
-      encoding:
-        codec: "json"
-      batch:
-        max_bytes: 10485760 # 10MB
-        timeout_secs: 30
-      key_prefix: "vector/logs/date=%Y-%m-%d/hour=%H/minute=%M/"  # Will be overridden by --set at deployment
-      filename_time_format: "%s"
-      filename_append_uuid: true
+    # DISABLED: s3_logs_sink - log forwarding disabled to avoid interfering with k9s/kubectl logs
+    # s3_logs_sink:
+    #   type: aws_s3
+    #   inputs: [kubernetes_logs]
+    #   bucket: "" # specify s3 bucket name
+    #   region: "" # specify s3 bucket region
+    #   compression: "gzip"
+    #   encoding:
+    #     codec: "json"
+    #   batch:
+    #     max_bytes: 10485760 # 10MB
+    #     timeout_secs: 30
+    #   key_prefix: "vector/logs/date=%Y-%m-%d/hour=%H/minute=%M/"  # Will be overridden by --set at deployment
+    #   filename_time_format: "%s"
+    #   filename_append_uuid: true
 # defaultVolumes -- Default volumes that are mounted into pods. In most cases, these should not be changed.
 # Use `extraVolumes`/`extraVolumeMounts` for additional custom volumes.
 # @default -- See `values.yaml`
+# NOTE: var-log removed since kubernetes_logs source is disabled
 defaultVolumes:
-  - name: var-log
-    hostPath:
-      path: "/var/log/"
+  # - name: var-log
+  #   hostPath:
+  #     path: "/var/log/"
   - name: var-lib
     hostPath:
       path: "/var/lib/"
@@ -447,10 +491,11 @@ defaultVolumes:
 
 # defaultVolumeMounts -- Default volume mounts. Corresponds to `volumes`.
 # @default -- See `values.yaml`
+# NOTE: var-log removed since kubernetes_logs source is disabled
 defaultVolumeMounts:
-  - name: var-log
-    mountPath: "/var/log/"
-    readOnly: true
+  # - name: var-log
+  #   mountPath: "/var/log/"
+  #   readOnly: true
   - name: var-lib
     mountPath: "/var/lib"
     readOnly: true

--- a/metrics/vector/values.yml
+++ b/metrics/vector/values.yml
@@ -345,7 +345,8 @@ customConfig:
     dcgm-exporter:
       type: prometheus_scrape
       endpoints:
-        - http://dcgm-exporters.cedana-monitoring.svc.cluster.local:9400/metrics
+        # Use GPU Operator's DCGM exporter - don't install separate dcgm-exporters helm chart
+        - http://nvidia-dcgm-exporter.gpu-operator.svc.cluster.local:9400/metrics
     node-exporter:
       type: prometheus_scrape
       endpoints:
@@ -429,19 +430,19 @@ customConfig:
         # Use Hostname from DCGM metrics (the actual GPU node), not Vector pod's node
         .tags.host = if exists(.tags.Hostname) { .tags.Hostname } else { get_env_var!("SPEC_NODE_NAME") }
         .tags.collector = "dcgm"
-    # Add reverse timestamp for newest-first S3 ordering
-    # S3Queue processes files lexicographically, so 9999999999 - unix_ts
-    # ensures newest files sort FIRST (smaller reverse_ts = newer data)
+    # Add timestamp for S3 path partitioning
+    # Normal timestamps ensure newer files sort AFTER older files lexicographically
+    # S3Queue with ordered mode processes old→new and always picks up new arrivals
     # NOTE: For metrics events, we must add to .tags map, not top-level
-    add_reverse_timestamp:
+    add_timestamp:
       type: remap
       inputs: [host_filter, cadvisor_tag, event_exporter_tag, kube_state_tag, dcgm_tag]
       source: |
-        .tags.reverse_ts = to_string(9999999999 - to_unix_timestamp(now()))
+        .tags.ts = to_string(to_unix_timestamp(now()))
   sinks:
     s3_sink:
       type: aws_s3
-      inputs: [add_reverse_timestamp]
+      inputs: [add_timestamp]
       bucket: "" # specify s3 bucket name
       region: "" # specify s3 bucket region
       compression: "none"
@@ -450,10 +451,10 @@ customConfig:
       batch:
         max_bytes: 10485760 # 10MB
         timeout_secs: 15  # Reduced from 60 for faster data availability
-      # Reverse timestamp prefix ensures newest data sorts FIRST lexicographically
-      # S3Queue with ordered mode will process newest files first
-      # Access tags.reverse_ts since metrics store custom fields in tags map
-      key_prefix: "vector/data/{{ tags.reverse_ts }}/"
+      # Normal timestamp prefix ensures newer files sort AFTER older files
+      # S3Queue with ordered mode processes chronologically, always picking up new arrivals
+      # Access tags.ts since metrics store custom fields in tags map
+      key_prefix: "vector/data/{{ tags.ts }}/"
       filename_time_format: "%s"
       filename_append_uuid: true
     # DISABLED: s3_logs_sink - log forwarding disabled to avoid interfering with k9s/kubectl logs

--- a/metrics/vector/values.yml
+++ b/metrics/vector/values.yml
@@ -341,15 +341,15 @@ customConfig:
     kube-state-metrics:
       type: prometheus_scrape
       endpoints:
-        - http://prometheus-kube-state-metrics.prometheus.svc.cluster.local:8080/metrics
+        - http://prometheus-kube-state-metrics.cedana-monitoring.svc.cluster.local:8080/metrics
     dcgm-exporter:
       type: prometheus_scrape
       endpoints:
-        - http://dcgm-exporters.prometheus.svc.cluster.local:9400/metrics
+        - http://dcgm-exporters.cedana-monitoring.svc.cluster.local:9400/metrics
     node-exporter:
       type: prometheus_scrape
       endpoints:
-        - http://prometheus-prometheus-node-exporter.prometheus.svc.cluster.local:9100/metrics
+        - http://prometheus-prometheus-node-exporter.cedana-monitoring.svc.cluster.local:9100/metrics
     host_metrics:
       type: host_metrics
       scrape_interval_secs: 60

--- a/metrics/vector/values.yml
+++ b/metrics/vector/values.yml
@@ -361,6 +361,12 @@ customConfig:
     host_metrics:
       type: host_metrics
       scrape_interval_secs: 60
+    # Kubernetes event exporter metrics - captures pod termination events (preemption, eviction, OOM)
+    event-exporter:
+      type: prometheus_scrape
+      endpoints:
+        - http://kubernetes-event-exporter.cedana-monitoring.svc.cluster.local:2112/metrics
+      scrape_interval_secs: 30
     kubernetes_logs:
       type: kubernetes_logs
       self_node_name: "${VECTOR_SELF_NODE_NAME}"
@@ -386,10 +392,17 @@ customConfig:
       source: |
         .tags.host = get_env_var!("SPEC_NODE_NAME")
         .tags.collector = "cadvisor"
+    # Tag event-exporter metrics
+    event_exporter_tag:
+      type: remap
+      inputs:
+        - event-exporter
+      source: |
+        .tags.collector = "event-exporter"
   sinks:
     s3_sink:
       type: aws_s3
-      inputs: [host_filter, cadvisor_tag]
+      inputs: [host_filter, cadvisor_tag, event_exporter_tag]
       bucket: "" # specify s3 bucket name
       region: "" # specify s3 bucket region
       compression: "none"

--- a/metrics/vector/values.yml
+++ b/metrics/vector/values.yml
@@ -185,16 +185,16 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
-  # - name: MY_VARIABLE
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: vector
-  #       key: my_variable
-  # - name: AWS_ACCESS_KEY_ID
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: vector
-  #       key: awsAccessKeyId
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: vector-aws-credentials
+        key: awsAccessKeyId
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: vector-aws-credentials
+        key: awsSecretAccessKey
 
 # envFrom -- Define environment variables from Secrets or ConfigMaps.
 envFrom: []
@@ -350,6 +350,14 @@ customConfig:
       type: prometheus_scrape
       endpoints:
         - http://prometheus-prometheus-node-exporter.cedana-monitoring.svc.cluster.local:9100/metrics
+    # cAdvisor metrics from Prometheus server - has pod name, namespace, container labels
+    # Use prometheus_remote_write instead - Prometheus pushes to Vector
+    # For now, scrape the federation endpoint with simpler encoding
+    cadvisor:
+      type: prometheus_scrape
+      endpoints:
+        - http://prometheus-server.cedana-monitoring.svc.cluster.local/federate?match[]=container_cpu_usage_seconds_total&match[]=container_memory_working_set_bytes
+      scrape_interval_secs: 60
     host_metrics:
       type: host_metrics
       scrape_interval_secs: 60
@@ -364,10 +372,24 @@ customConfig:
         - host_metrics
       source: |
         .tags.host = get_env_var!("SPEC_NODE_NAME")
+    # Filter and tag cAdvisor metrics - CPU and memory for pods
+    cadvisor_filter:
+      type: filter
+      inputs:
+        - cadvisor
+      condition: |
+        starts_with(string!(.name), "container_cpu_") || starts_with(string!(.name), "container_memory_")
+    cadvisor_tag:
+      type: remap
+      inputs:
+        - cadvisor_filter
+      source: |
+        .tags.host = get_env_var!("SPEC_NODE_NAME")
+        .tags.collector = "cadvisor"
   sinks:
     s3_sink:
       type: aws_s3
-      inputs: [host_filter]
+      inputs: [host_filter, cadvisor_tag]
       bucket: "" # specify s3 bucket name
       region: "" # specify s3 bucket region
       compression: "none"


### PR DESCRIPTION
## Describe your changes

## Checklist before requesting a review

- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cluster monitoring/RBAC and metric shipping paths (new scrapes, altered endpoints, new ClusterRole/Binding), which can break observability if misconfigured but do not touch application runtime logic.
> 
> **Overview**
> Updates the `metrics` install docs to a single *quickstart* flow that standardizes on the `cedana-monitoring` namespace, uses a dedicated `vector-aws-credentials` Secret, and documents optional components (Kubernetes event exporter + DCGM exporter).
> 
> Adds a standalone Kubernetes Event Exporter manifest and wires it into Vector scraping. Prometheus config is simplified to rely on chart defaults while adding cAdvisor scraping (plus required `nodes/proxy` RBAC), and Vector is reworked to ship a broader set of metrics to S3 (cAdvisor via Prometheus federation, event-exporter, filtered kube-state-metrics, filtered DCGM), with updated S3 key partitioning and log forwarding disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc88cf19d44aeec34a29fe2ca5c13bb1a9cefffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->