### PR TITLE
Feat: make criu log level configurable

### DIFF
--- a/cedana-helm/templates/_checksum-helper-config.tpl
+++ b/cedana-helm/templates/_checksum-helper-config.tpl
@@ -29,6 +29,7 @@
   "awsRegion"
   "awsEndpoint"
   "preExistingSecret"
+  "criuLogLevel"
 -}}
 {{- range $key := $configKeysFromValuesConfig -}}
   {{- if hasKey $.Values.config $key -}}

--- a/cedana-helm/templates/configmap.yaml
+++ b/cedana-helm/templates/configmap.yaml
@@ -39,4 +39,6 @@ data:
   shm-config-enabled: "{{ .Values.hostConfig.shmConfig.enabled }}"
   shm-config-size: "{{ .Values.hostConfig.shmConfig.size }}"
   shm-config-min-size: "{{ .Values.hostConfig.shmConfig.minSize }}"
+
+  criu-log-level: "{{ .Values.config.criuLogLevel }}"
 {{- end }}

--- a/cedana-helm/templates/helper-daemonset.yaml
+++ b/cedana-helm/templates/helper-daemonset.yaml
@@ -128,6 +128,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: checkpoint-stream-memory-limit
+            - name: CEDANA_CRIU_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: criu-log-level
             - name: CEDANA_CHECKPOINT_COMPRESSION
               valueFrom:
                 configMapKeyRef:

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -64,7 +64,7 @@ config:
   awsRegion: # AWS region if using S3 storage (uses default region if not set)
   awsEndpoint: # AWS endpoint if using S3-compatible storage
 
-  criuLogLevel: 4
+  criuLogLevel: 2
   # Uncomment, to use custom pre-existing secret
   # preExistingSecret: cedana-secret-user
 

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -64,6 +64,7 @@ config:
   awsRegion: # AWS region if using S3 storage (uses default region if not set)
   awsEndpoint: # AWS endpoint if using S3-compatible storage
 
+  criuLogLevel: 4
   # Uncomment, to use custom pre-existing secret
   # preExistingSecret: cedana-secret-user
 


### PR DESCRIPTION
## Describe your changes
Since CRIU log level got separated from the daemon log level there is no way to modify the CRIU log level inside k8s, so add the ability to modify the daemon's CEDANA_CRIU_LOG_LEVEL env var from the helm chart.
Unlikely a customer is going to need this, but is very useful for debugging.
The other alternative is to make the CRIU log level override able by a request in the daemon. 

## Checklist before requesting a review

- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.
