### PR TITLE
feat(nebius): deploy the inference stack

### DIFF
--- a/cedana-helm/templates/_checksum-helper-config.tpl
+++ b/cedana-helm/templates/_checksum-helper-config.tpl
@@ -16,6 +16,8 @@
   "checkpointAsync"
   "gpuPoolSize"
   "gpuShmSize"
+  "gpuDedupEnabled"
+  "gpuTemplatesEnabled"
   "pluginsBuilds"
   "pluginsCriuVersion"
   "pluginsContainerdRuntimeVersion"

--- a/cedana-helm/templates/_checksum-helper-config.tpl
+++ b/cedana-helm/templates/_checksum-helper-config.tpl
@@ -24,6 +24,7 @@
   "pluginsGpuVersion"
   "pluginsStreamerVersion"
   "pluginsLocalSearchPath"
+  "dbRemote"
   "profiling"
   "metrics"
   "logLevel"

--- a/cedana-helm/templates/_checksum-helper-config.tpl
+++ b/cedana-helm/templates/_checksum-helper-config.tpl
@@ -23,6 +23,7 @@
   "pluginsContainerdRuntimeVersion"
   "pluginsGpuVersion"
   "pluginsStreamerVersion"
+  "pluginsLocalSearchPath"
   "profiling"
   "metrics"
   "logLevel"

--- a/cedana-helm/templates/configmap.yaml
+++ b/cedana-helm/templates/configmap.yaml
@@ -21,6 +21,8 @@ data:
   checkpoint-async: "{{ .Values.config.checkpointAsync }}"
   gpu-pool-size: "{{ .Values.config.gpuPoolSize }}"
   gpu-shm-size: "{{ .Values.config.gpuShmSize }}"
+  gpu-dedup-enabled: "{{ .Values.config.gpuDedupEnabled }}"
+  gpu-templates-enabled: "{{ .Values.config.gpuTemplatesEnabled }}"
   plugins-builds: "{{ .Values.config.pluginsBuilds }}"
   plugins-criu-version: "{{ .Values.config.pluginsCriuVersion }}"
   plugins-containerd-runtime-version: "{{ .Values.config.pluginsContainerdRuntimeVersion }}"

--- a/cedana-helm/templates/configmap.yaml
+++ b/cedana-helm/templates/configmap.yaml
@@ -28,6 +28,7 @@ data:
   plugins-containerd-runtime-version: "{{ .Values.config.pluginsContainerdRuntimeVersion }}"
   plugins-gpu-version: "{{ .Values.config.pluginsGpuVersion }}"
   plugins-streamer-version: "{{ .Values.config.pluginsStreamerVersion }}"
+  plugins-local-search-path: "{{ .Values.config.pluginsLocalSearchPath }}"
   metrics: "{{ .Values.config.metrics }}"
   profiling: "{{ .Values.config.profiling }}"
   log-level: "{{ .Values.config.logLevel }}"

--- a/cedana-helm/templates/health-check-daemonset.yaml
+++ b/cedana-helm/templates/health-check-daemonset.yaml
@@ -138,6 +138,20 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: gpu-shm-size
+            - name: CEDANA_GPU_DEDUP_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: gpu-dedup-enabled
+                  # optional so a pre-existing ConfigMap (created before these keys
+                  # existed) doesn't break pod startup; absent => daemon default (false)
+                  optional: true
+            - name: CEDANA_GPU_TEMPLATES_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: gpu-templates-enabled
+                  optional: true
             - name: CEDANA_PLUGINS_BUILDS
               valueFrom:
                 configMapKeyRef:

--- a/cedana-helm/templates/helper-daemonset.yaml
+++ b/cedana-helm/templates/helper-daemonset.yaml
@@ -228,8 +228,17 @@ spec:
               value: "/etc/containerd/config.toml"
             - name: CEDANA_CLIENT_WAIT_FOR_READY
               value: "true"
+            # Remote mode makes the daemon PUT its host record to the
+            # propagator. A propagator build without the /hosts API 404s and the
+            # daemon refuses to start, so this is settable per deployment.
+            # `default` treats false as empty, so an explicit false would be
+            # silently turned back into true — test for the key instead.
             - name: CEDANA_DB_REMOTE
+              {{- if hasKey .Values.config "dbRemote" }}
+              value: {{ .Values.config.dbRemote | quote }}
+              {{- else }}
               value: "true"
+              {{- end }}
             - name: CEDANA_AWS_CREDENTIALS_MODE
               value: {{ include "cedana-helm.awsCredentialsMode" . | quote }}
             {{- if eq (include "cedana-helm.awsCredentialsMode" .) "static" }}

--- a/cedana-helm/templates/helper-daemonset.yaml
+++ b/cedana-helm/templates/helper-daemonset.yaml
@@ -155,6 +155,20 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: gpu-shm-size
+            - name: CEDANA_GPU_DEDUP_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: gpu-dedup-enabled
+                  # optional so a pre-existing ConfigMap (created before these keys
+                  # existed) doesn't break pod startup; absent => daemon default (false)
+                  optional: true
+            - name: CEDANA_GPU_TEMPLATES_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: gpu-templates-enabled
+                  optional: true
             - name: CEDANA_PLUGINS_BUILDS
               valueFrom:
                 configMapKeyRef:

--- a/cedana-helm/templates/helper-daemonset.yaml
+++ b/cedana-helm/templates/helper-daemonset.yaml
@@ -194,6 +194,14 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: plugins-streamer-version
+            - name: CEDANA_PLUGINS_LOCAL_SEARCH_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: plugins-local-search-path
+                  # optional so a pre-existing ConfigMap (created before this key
+                  # existed) doesn't break pod startup; absent => registry only
+                  optional: true
             - name: CEDANA_PROFILING_ENABLED
               valueFrom:
                 configMapKeyRef:

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -1,7 +1,7 @@
 # Cedana systems release values - Nebius inference stack (2026-08-12)
 # Points helper/watcher/manager at the in-cluster propagator.
 config:
-  url: http://propagator.cedana-inference.svc.cluster.local:1324
+  url: http://10.0.163.250:1324/v1
   authToken: REDACTED_ROTATED_SEE_SECRET_MANAGER
   clusterId: e414ae14-8fb9-4572-b201-2c62d9fe084d
   # Checkpoint storage on Nebius object storage
@@ -11,6 +11,14 @@ config:
   awsSecretAccessKey: REDACTED_ROTATED_SEE_SECRET_MANAGER
   checkpointAsync: true
   pluginsBuilds: alpha
+  # Plugin artifacts are baked into the helper image and staged onto the host by
+  # plugins/k8s/scripts/install.sh; `plugin install` resolves them from here and
+  # never reaches the (empty) registry. Path is read inside the chroot, so it is
+  # the host path with no /host prefix.
+  pluginsLocalSearchPath: /opt/cedana/plugins
+  # No GPU plugin artifact is baked yet and the L40S group is scaled to 0, so the
+  # GPU plugin is explicitly disabled instead of being looked up in the registry.
+  pluginsGpuVersion: none
   gpuDedupEnabled: true
   gpuTemplatesEnabled: false
   gpuPoolSize: 0
@@ -19,8 +27,17 @@ config:
 daemonHelper:
   enabled: true
   image:
+    # Built by cedana-nebius/scripts/build-helper-image.sh: the monorepo helper
+    # plus criu, the containerd shim, and the runc/containerd .so files baked
+    # into /opt/cedana/plugins.
     repository: cedana/cedana-helper
-    digest: sha256:67319212f89e2bc819438035f8a613b65979045f4663bc85a44d6088e33e6718
+    digest: sha256:0c7dd1a66356ddc508bbfac2da1fae3f2c7f1a236f567bea9c75579fad28570a
+  # Checkpoint/restore only ever runs on the L40S nodes, so the helper only runs
+  # there. It rewrites kubelet config and installs a host service; keeping it off
+  # the control nodes keeps the databases, propagator, and UI out of its blast
+  # radius. With the GPU group scaled to 0 this DaemonSet has no nodes at all.
+  nodeSelector:
+    nebius.com/gpu-name: L40S
   tolerations:
     - key: "cedana.ai/not-ready"
       operator: "Exists"

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -55,9 +55,12 @@ daemonHelper:
 controllerManager:
   enabled: true
   manager:
+    # Built from current cedana-controller HEAD. v0.6.5 predates
+    # reconcileOutOfScopeTaints, so with the helper pinned to GPU nodes it left
+    # the CPU nodes tainted not-ready forever and nothing could schedule.
     image:
       repository: cedana/cedana-controller
-      tag: v0.6.5
+      digest: sha256:c2fd061a98765aaf7ffb523ae0ac0ee10c3f1bee0bae948178dc42da07628171
 
 dynamoWatcher:
   enabled: true

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -16,9 +16,16 @@ config:
   # never reaches the (empty) registry. Path is read inside the chroot, so it is
   # the host path with no /host prefix.
   pluginsLocalSearchPath: /opt/cedana/plugins
-  # No GPU plugin artifact is baked yet and the L40S group is scaled to 0, so the
-  # GPU plugin is explicitly disabled instead of being looked up in the registry.
-  pluginsGpuVersion: none
+  # This propagator build serves the inference API but no /hosts endpoint, so
+  # remote host registration would 404 and stop the daemon before it starts.
+  dbRemote: false
+  # SigNoz is not part of this stack and this propagator serves no
+  # /otel/credentials, so leaving metrics on only produces a failed fetch on
+  # every daemon start. Dynamo/Switchyard metrics reach propagator directly.
+  metrics: false
+  # Baked into the helper image from the Cedana CI plugin registry, so this is
+  # resolved locally like the others and never downloaded on the node.
+  pluginsGpuVersion: v0.7.3
   gpuDedupEnabled: true
   gpuTemplatesEnabled: false
   gpuPoolSize: 0
@@ -31,7 +38,7 @@ daemonHelper:
     # plus criu, the containerd shim, and the runc/containerd .so files baked
     # into /opt/cedana/plugins.
     repository: cedana/cedana-helper
-    digest: sha256:0c7dd1a66356ddc508bbfac2da1fae3f2c7f1a236f567bea9c75579fad28570a
+    digest: sha256:ad8711b00ffb24bfd45cf4c9c199be6bc61dfb5b3fe0330fa5783b9ad0ecfa11
   # Checkpoint/restore only ever runs on the L40S nodes, so the helper only runs
   # there. It rewrites kubelet config and installs a host service; keeping it off
   # the control nodes keeps the databases, propagator, and UI out of its blast
@@ -58,7 +65,7 @@ dynamoWatcher:
   inferenceNamespace: inference
   image:
     repository: cedana/cedana-dynamo-watcher
-    digest: sha256:02d2fa357cccce1a6ccc4676d1ab408b99a68eef47369df3a24e4fe1f87dabf3
+    digest: sha256:2306bd73eeffcaf65f93d8d8f0641768c9ae95bfb9ac7e67a27b8543c6dc2310
   experiments:
     gpuNodeSelector:
       nebius.com/gpu-name: L40S

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -3,7 +3,7 @@
 config:
   url: http://propagator.cedana-inference.svc.cluster.local:1324
   authToken: REDACTED_ROTATED_SEE_SECRET_MANAGER
-  clusterId: 3ea3174f-6cb8-4b2e-99c9-2d9c6ff0adb8
+  clusterId: e414ae14-8fb9-4572-b201-2c62d9fe084d
   # Checkpoint storage on Nebius object storage
   awsAccessKeyId: REDACTED_ROTATED_SEE_SECRET_MANAGER
   awsEndpoint: https://storage.eu-north1.nebius.cloud

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -1,0 +1,54 @@
+# Cedana systems release values - Nebius inference stack (2026-08-12)
+# Points helper/watcher/manager at the in-cluster propagator.
+config:
+  url: http://propagator.cedana-inference.svc.cluster.local:1324
+  authToken: REDACTED_ROTATED_SEE_SECRET_MANAGER
+  clusterId: 3ea3174f-6cb8-4b2e-99c9-2d9c6ff0adb8
+  # Checkpoint storage on Nebius object storage
+  awsAccessKeyId: REDACTED_ROTATED_SEE_SECRET_MANAGER
+  awsEndpoint: https://storage.eu-north1.nebius.cloud
+  awsRegion: eu-north1
+  awsSecretAccessKey: REDACTED_ROTATED_SEE_SECRET_MANAGER
+  checkpointAsync: true
+  pluginsBuilds: alpha
+  gpuDedupEnabled: true
+  gpuTemplatesEnabled: false
+  gpuPoolSize: 0
+  gpuShmSize: "8589934592"
+
+daemonHelper:
+  enabled: true
+  image:
+    repository: cedana/cedana-helper
+    digest: sha256:67319212f89e2bc819438035f8a613b65979045f4663bc85a44d6088e33e6718
+  tolerations:
+    - key: "cedana.ai/not-ready"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "nebius.com/preemptible"
+      operator: "Exists"
+
+controllerManager:
+  enabled: true
+  manager:
+    image:
+      repository: cedana/cedana-controller
+      tag: v0.6.5
+
+dynamoWatcher:
+  enabled: true
+  createLoadBalancer: false
+  inferenceNamespace: inference
+  image:
+    repository: cedana/cedana-dynamo-watcher
+    digest: sha256:02d2fa357cccce1a6ccc4676d1ab408b99a68eef47369df3a24e4fe1f87dabf3
+  experiments:
+    gpuNodeSelector:
+      nebius.com/gpu-name: L40S
+    gpuTolerations:
+      - key: nebius.com/preemptible
+        operator: Exists
+  tolerations:
+    - key: "cedana.ai/not-ready"
+      operator: "Exists"
+      effect: "NoSchedule"

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -60,6 +60,9 @@ config:
   # registry. Set this together with a helper image that bakes plugin artifacts
   # into the same path; leave empty to always download from the registry.
   pluginsLocalSearchPath: ""
+  # Register the daemon's host record with the propagator. Requires a
+  # propagator that serves the /hosts API; set false against one that does not.
+  dbRemote: true
 
   profiling: true
   metrics: true

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -56,6 +56,10 @@ config:
   pluginsContainerdRuntimeVersion: v0.7.5
   pluginsGpuVersion: v0.7.3
   pluginsStreamerVersion: v0.1.0
+  # Directory on the host that `cedana plugin install` searches before hitting the
+  # registry. Set this together with a helper image that bakes plugin artifacts
+  # into the same path; leave empty to always download from the registry.
+  pluginsLocalSearchPath: ""
 
   profiling: true
   metrics: true

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -46,6 +46,8 @@ config:
 
   gpuPoolSize: 0 # Number of GPU controllers to keep warm. Improves GPU workload startup/restore time but uses more memory.
   gpuShmSize: "8589934592" # 8 GiB. Enough for most workloads. Reduce if memory constrained or running small workloads only.
+  gpuDedupEnabled: true # Enable deduplication for GPU checkpoints to reduce checkpoint size.
+  gpuTemplatesEnabled: false # Enable templates for GPU checkpoint/restore.
 
   # Specify the plugin versions to use. If pluginsBuilds is "release", then any release version
   # for the plugins can be specified. If pluginsBuilds is "alpha", then specify the branch name.

--- a/manifests/nebius/README.md
+++ b/manifests/nebius/README.md
@@ -1,0 +1,27 @@
+# Nebius inference stack manifests (cedana-helm-charts)
+
+Deployment artifacts for `nebius-mk8s-purple-snail-cluster-8`, as of 2026-08-12.
+
+## cedana-helm/values-nebius.yaml
+Upgrade values for the `cedana` release in `cedana-systems` (canonical chart):
+pins the fixed helper image digest (idempotent kubelet config), enables the
+dynamo-watcher with `INFERENCE_NAMESPACE=inference`, points config at the
+in-cluster propagator, keeps manager v0.6.5 until the watcher gate passes.
+
+```sh
+helm upgrade cedana ./cedana-helm -n cedana-systems -f cedana-helm/values-nebius.yaml
+```
+
+## manifests/nebius/propagator-env.yaml
+Propagator env wiring: `propagator-aws` secret (operator .env values) via
+envFrom (S3 plugin registry) + FQDN RabbitMQ discovery URI.
+
+## manifests/nebius/cedana-ui.yaml
+cedana-ui deployment (backend AUTH_MODE=custom + frontend + caddy) exposed via
+`cedana-ui` LoadBalancer in `cedana-inference`. Login: paste the shared
+`CEDANA_AUTH_TOKEN` from the `cedana-inference-auth` secret on the token screen.
+
+```sh
+kubectl get secret cedana-inference-auth -n cedana-inference \
+  -o jsonpath='{.data.auth-token}' | base64 -d
+```

--- a/manifests/nebius/cedana-ui.yaml
+++ b/manifests/nebius/cedana-ui.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cedana-ui-caddy
+  namespace: cedana-inference
+data:
+  Caddyfile: |
+    :7070 {
+        reverse_proxy /api/* localhost:3031
+        reverse_proxy localhost:3000
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cedana-ui
+  namespace: cedana-inference
+  annotations:
+    service.beta.kubernetes.io/nebius-load-balancer-allowed-cidrs: 0.0.0.0/0
+spec:
+  type: LoadBalancer
+  selector: {app: cedana-ui}
+  ports:
+  - {name: http, port: 80, targetPort: http}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cedana-ui
+  namespace: cedana-inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: cedana-ui}
+  template:
+    metadata:
+      labels: {app: cedana-ui}
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        inference.cedana.ai/node-role: control
+      tolerations:
+      - {key: CriticalAddonsOnly, operator: Exists, effect: NoSchedule}
+      - {key: cedana.ai/not-ready, operator: Exists, effect: NoSchedule}
+      containers:
+      - name: backend
+        image: cedana/cedana-ui-backend:nebius-amd64-20260812
+        imagePullPolicy: IfNotPresent
+        env:
+        - {name: AUTH_MODE, value: custom}
+        - {name: PROPAGATOR_SCHEME, value: http}
+        - {name: PROPAGATOR_URL, value: "propagator:1324"}
+        - {name: SERVER_PORT, value: "3031"}
+        - {name: SESSION_COOKIE_SECURE, value: "false"}
+        - name: CEDANA_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef: {name: cedana-inference-auth, key: auth-token}
+        ports: [{name: api, containerPort: 3031}]
+        readinessProbe: {tcpSocket: {port: api}, periodSeconds: 10}
+        resources:
+          requests: {cpu: 50m, memory: 96Mi}
+          limits: {cpu: "1", memory: 512Mi}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities: {drop: [ALL]}
+      - name: frontend
+        image: cedana/cedana-ui-frontend:nebius-amd64-20260812
+        imagePullPolicy: IfNotPresent
+        ports: [{name: web, containerPort: 3000}]
+        resources:
+          requests: {cpu: 10m, memory: 32Mi}
+          limits: {cpu: 100m, memory: 128Mi}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities: {drop: [ALL]}
+      - name: caddy
+        image: caddy:2.7.6-alpine
+        imagePullPolicy: IfNotPresent
+        ports: [{name: http, containerPort: 7070}]
+        volumeMounts:
+        - {name: caddy-config, mountPath: /etc/caddy/Caddyfile, subPath: Caddyfile, readOnly: true}
+        readinessProbe: {httpGet: {path: /, port: http}, periodSeconds: 10}
+        resources:
+          requests: {cpu: 10m, memory: 16Mi}
+          limits: {cpu: 100m, memory: 64Mi}
+      volumes:
+      - name: caddy-config
+        configMap: {name: cedana-ui-caddy}

--- a/manifests/nebius/cedana-ui.yaml
+++ b/manifests/nebius/cedana-ui.yaml
@@ -44,7 +44,11 @@ spec:
       - {key: cedana.ai/not-ready, operator: Exists, effect: NoSchedule}
       containers:
       - name: backend
-        image: cedana/cedana-ui-backend:nebius-amd64-20260812
+        # Pinned by digest, not tag. The `…-20260813i` tag was rebuilt after its
+        # first push, and `IfNotPresent` happily kept serving the stale layer the
+        # node had already cached — the rollout reported success while running
+        # the old bundle. A digest cannot drift under us.
+        image: cedana/cedana-ui-backend@sha256:073303c7e4ff5a7d240d32c1c19113be737ba4af82b0f913500c2b7179b3b8fe  # nebius-amd64-20260813i
         imagePullPolicy: IfNotPresent
         env:
         - {name: AUTH_MODE, value: custom}
@@ -52,6 +56,15 @@ spec:
         - {name: PROPAGATOR_URL, value: "propagator:1324"}
         - {name: SERVER_PORT, value: "3031"}
         - {name: SESSION_COOKIE_SECURE, value: "false"}
+        # The public OpenAI-compatible origin external clients dial: the
+        # `cedana-inference-endpoint` LoadBalancer in front of Switchyard. No
+        # propagator API publishes it (see cedana-ui/MISSING_APIS.md §3), and
+        # deriving it from the propagator host would hand out a URL that looks
+        # right and fails on every request — so it is configured here.
+        - {name: INFERENCE_GATEWAY_URL, value: "http://195.242.31.5"}
+        # One L40S, so one model loaded at a time. Nothing upstream reports
+        # accelerator inventory (§3b); the UI warns before activating past this.
+        - {name: INFERENCE_MAX_LOADED_MODELS, value: "1"}
         - name: CEDANA_AUTH_TOKEN
           valueFrom:
             secretKeyRef: {name: cedana-inference-auth, key: auth-token}
@@ -64,7 +77,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities: {drop: [ALL]}
       - name: frontend
-        image: cedana/cedana-ui-frontend:nebius-amd64-20260812
+        image: cedana/cedana-ui-frontend@sha256:3d1d4a4eb7837091800afdb23fc41c2250ef08a813f01146c7d413c2e3a1fac7  # nebius-amd64-20260813i
         imagePullPolicy: IfNotPresent
         ports: [{name: web, containerPort: 3000}]
         resources:

--- a/manifests/nebius/kustomization.yaml
+++ b/manifests/nebius/kustomization.yaml
@@ -1,0 +1,19 @@
+# Nebius inference stack manifests. Apply with:
+#   kubectl kustomize manifests/nebius | kubectl apply -f -
+#
+# Propagator env wiring is applied separately (the deployment is helm-managed,
+# so it is patched, not re-created):
+#   kubectl patch deployment propagator -n cedana-inference \
+#     --patch-file manifests/nebius/propagator-env.yaml
+#
+# Requires the propagator-aws secret (see propagator-env.yaml header):
+#   set -a && . ./.env && set +a
+#   kubectl create secret generic propagator-aws -n cedana-inference \
+#     --from-literal=AWS_REGION="$AWS_REGION" \
+#     --from-literal=AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+#     --from-literal=AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+#     --from-literal=BUCKET_NAME="$BUCKET_NAME"
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cedana-ui.yaml

--- a/manifests/nebius/propagator-env.yaml
+++ b/manifests/nebius/propagator-env.yaml
@@ -1,7 +1,8 @@
 # Propagator environment wiring for the Nebius inference stack.
 #
-# Apply with:
-#   kubectl apply -f manifests/nebius/propagator-env.yaml
+# Strategic merge patch for the helm-managed propagator Deployment. Apply:
+#   kubectl patch deployment propagator -n cedana-inference \
+#     --type strategic --patch-file manifests/nebius/propagator-env.yaml
 #
 # 1. `propagator-aws` secret: AWS_REGION / AWS_ACCESS_KEY_ID /
 #    AWS_SECRET_ACCESS_KEY / BUCKET_NAME. Create it from the operator .env
@@ -15,7 +16,6 @@
 # 2. Wire envFrom on the propagator deployment so the plugin registry (S3)
 #    works, and advertise RabbitMQ with its fully-qualified in-cluster host so
 #    cross-namespace consumers (cedana-systems watcher/helper) can connect.
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/nebius/propagator-env.yaml
+++ b/manifests/nebius/propagator-env.yaml
@@ -1,0 +1,34 @@
+# Propagator environment wiring for the Nebius inference stack.
+#
+# Apply with:
+#   kubectl apply -f manifests/nebius/propagator-env.yaml
+#
+# 1. `propagator-aws` secret: AWS_REGION / AWS_ACCESS_KEY_ID /
+#    AWS_SECRET_ACCESS_KEY / BUCKET_NAME. Create it from the operator .env
+#    (values never committed):
+#     set -a && . ./.env && set +a
+#     kubectl create secret generic propagator-aws -n cedana-inference \
+#       --from-literal=AWS_REGION="$AWS_REGION" \
+#       --from-literal=AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+#       --from-literal=AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+#       --from-literal=BUCKET_NAME="$BUCKET_NAME"
+# 2. Wire envFrom on the propagator deployment so the plugin registry (S3)
+#    works, and advertise RabbitMQ with its fully-qualified in-cluster host so
+#    cross-namespace consumers (cedana-systems watcher/helper) can connect.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: propagator
+  namespace: cedana-inference
+spec:
+  template:
+    spec:
+      containers:
+        - name: propagator
+          envFrom:
+            - secretRef:
+                name: propagator-aws
+          env:
+            - name: RABBITMQ_DISCOVERY_URI
+              value: "amqp://cedana:cedana-test-only@rabbitmq.cedana-inference.svc.cluster.local:5672"

--- a/manifests/nebius/qwen36-model-cache.yaml
+++ b/manifests/nebius/qwen36-model-cache.yaml
@@ -37,9 +37,11 @@ spec:
       containers:
         - name: download
           image: python:3.12-slim
-          command: [python, -c]
+          command: [sh, -ec]
           args:
             - |
+              pip install -q huggingface_hub==0.30.2
+              python - <<'PY'
               import json, os, sys
               from huggingface_hub import snapshot_download, list_repo_tree
 
@@ -103,6 +105,7 @@ spec:
               total = sum(s for _, s in expected)
               print(f"verified {len(expected)} files, {total / 1e9:.1f} GB at {REV}")
               open(MARKER, "w").write(REV)
+              PY
           env:
             - {name: HF_HUB_DISABLE_TELEMETRY, value: "1"}
           resources:

--- a/manifests/nebius/qwen36-model-cache.yaml
+++ b/manifests/nebius/qwen36-model-cache.yaml
@@ -1,0 +1,115 @@
+# Qwen3.6-27B-FP8 model cache: 80Gi PVC + verified snapshot downloader.
+#
+# Downloads Qwen/Qwen3.6-27B-FP8 at the pinned revision into
+# /cache/Qwen3.6-27B-FP8. Verifies every expected file's byte size against
+# the Hugging Face revision tree and the snapshot's resolved commit hash
+# before the Job completes. Idempotent: a completed verification skips the
+# download. Never mutates the existing qwen3-model-cache PVC.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen36-model-cache
+  namespace: inference
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: compute-csi-default-sc
+  resources:
+    requests:
+      storage: 80Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen36-model-cache-download
+  namespace: inference
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      nodeSelector:
+        inference.cedana.ai/node-role: control
+      tolerations:
+        - {key: CriticalAddonsOnly, operator: Exists, effect: NoSchedule}
+        - {key: cedana.ai/not-ready, operator: Exists, effect: NoSchedule}
+      containers:
+        - name: download
+          image: python:3.12-slim
+          command: [python, -c]
+          args:
+            - |
+              import json, os, sys
+              from huggingface_hub import snapshot_download, list_repo_tree
+
+              REPO = "Qwen/Qwen3.6-27B-FP8"
+              REV = "e89b16ebf1988b3d6befa7de50abc2d76f26eb09"
+              DEST = "/cache/Qwen3.6-27B-FP8"
+              MARKER = "/cache/.qwen36-verified"
+
+              if os.path.exists(MARKER):
+                  print("snapshot already verified; skipping download")
+                  sys.exit(0)
+
+              expected = [
+                  (e.path, e.size)
+                  for e in list_repo_tree(REPO, revision=REV, recursive=True)
+                  if e.type == "file"
+              ]
+              print(f"expected {len(expected)} files at revision {REV[:12]}")
+              if not expected:
+                  print("empty revision tree; aborting")
+                  sys.exit(1)
+
+              snapshot_download(
+                  repo_id=REPO,
+                  revision=REV,
+                  local_dir=DEST,
+                  local_dir_use_symlinks=False,
+                  allow_patterns="*",
+              )
+
+              # Every expected file present with the exact byte size.
+              bad = []
+              for path, size in expected:
+                  full = os.path.join(DEST, path)
+                  if not os.path.exists(full):
+                      bad.append(f"missing {path}")
+                  elif os.path.getsize(full) != size:
+                      bad.append(f"size {path}: {os.path.getsize(full)} != {size}")
+              if bad:
+                  print("\n".join(bad[:20]))
+                  sys.exit(1)
+
+              # Snapshot resolved commit: verify against the pinned revision.
+              meta_root = os.path.join(DEST, ".cache", "huggingface", "download")
+              commits = set()
+              for root, _, files in os.walk(meta_root):
+                  for name in files:
+                      if not name.endswith(".json"):
+                          continue
+                      try:
+                          meta = json.load(open(os.path.join(root, name)))
+                          if meta.get("commit"):
+                              commits.add(meta["commit"])
+                      except Exception:
+                          pass
+              print(f"resolved commits: {sorted(commits)}")
+              if REV not in commits:
+                  print(f"snapshot did not resolve to pinned revision {REV}")
+                  sys.exit(1)
+
+              total = sum(s for _, s in expected)
+              print(f"verified {len(expected)} files, {total / 1e9:.1f} GB at {REV}")
+              open(MARKER, "w").write(REV)
+          env:
+            - {name: HF_HUB_DISABLE_TELEMETRY, value: "1"}
+          resources:
+            requests: {cpu: "2", memory: 6Gi}
+            limits: {cpu: "4", memory: 12Gi}
+          volumeMounts:
+            - {name: cache, mountPath: /cache}
+      volumes:
+        - name: cache
+          persistentVolumeClaim: {claimName: qwen36-model-cache}

--- a/manifests/nebius/qwen36-model-cache.yaml
+++ b/manifests/nebius/qwen36-model-cache.yaml
@@ -44,6 +44,9 @@ spec:
               python - <<'PY'
               import json, os, sys
               from huggingface_hub import snapshot_download, list_repo_tree
+              # 0.30.x yields RepoFile/RepoFolder objects, which carry no
+              # `.type` discriminator — select files by class instead.
+              from huggingface_hub.hf_api import RepoFile
 
               REPO = "Qwen/Qwen3.6-27B-FP8"
               REV = "e89b16ebf1988b3d6befa7de50abc2d76f26eb09"
@@ -57,7 +60,7 @@ spec:
               expected = [
                   (e.path, e.size)
                   for e in list_repo_tree(REPO, revision=REV, recursive=True)
-                  if e.type == "file"
+                  if isinstance(e, RepoFile)
               ]
               print(f"expected {len(expected)} files at revision {REV[:12]}")
               if not expected:

--- a/manifests/nebius/qwen36-model-cache.yaml
+++ b/manifests/nebius/qwen36-model-cache.yaml
@@ -85,16 +85,25 @@ spec:
                   sys.exit(1)
 
               # Snapshot resolved commit: verify against the pinned revision.
+              # huggingface_hub has used two side-car formats — older builds
+              # write <file>.json carrying {"commit": ...}, 0.30.x writes
+              # <file>.metadata whose first line is the commit hash. Read both,
+              # otherwise the check silently finds nothing and fails a download
+              # that actually succeeded.
               meta_root = os.path.join(DEST, ".cache", "huggingface", "download")
               commits = set()
               for root, _, files in os.walk(meta_root):
                   for name in files:
-                      if not name.endswith(".json"):
-                          continue
+                      full = os.path.join(root, name)
                       try:
-                          meta = json.load(open(os.path.join(root, name)))
-                          if meta.get("commit"):
-                              commits.add(meta["commit"])
+                          if name.endswith(".json"):
+                              meta = json.load(open(full))
+                              if meta.get("commit"):
+                                  commits.add(meta["commit"])
+                          elif name.endswith(".metadata"):
+                              first = open(full).readline().strip()
+                              if first:
+                                  commits.add(first)
                       except Exception:
                           pass
               print(f"resolved commits: {sorted(commits)}")


### PR DESCRIPTION
## What

Manifests and values to deploy the Cedana inference stack on the Nebius cluster.

- kustomize-based Nebius manifests; propagator env applied as a documented
  strategic-merge `kubectl` patch rather than a chart value, because that is what
  it actually is
- a model-cache downloader job for Qwen3.6, with `huggingface_hub` installed in it
- a local plugin search path, and the helper pinned to the GPU nodes
- the baked GPU plugin enabled; remote host DB and SigNoz metrics disabled for
  this cluster
- manager image from HEAD, for out-of-scope taint clearing
- UI images pinned by digest, with gateway settings passed through

## Why

This is the deployment the whole checkpoint/restore result was measured on: a
single-L40S Nebius Kubernetes cluster running vLLM under Dynamo. The values
capture decisions that are not obvious and were each arrived at by something
failing — the digest pinning in particular, because a floating tag silently
dropped the UI's auth mode.

## Stacking

Base is `feat/controller-integration-dynamo-inference`. First PR in a three-part
stack:

1. **`swarnim/nebius-inference-stack`** (this PR)
2. `swarnim/nebius-checkpoint-tmpfs`
3. `swarnim/dynamo-watcher-node-rbac`

## Depends on

- **cedana-controller `swarnim/dynamo-profile-deployment`** — the controller that
  deploys against these manifests.
- **cedana-nebius** holds the operational scripts that drive this stack.
  ⚠️ Not in a PR: that repo has **no git remote configured at all**, so it cannot
  be pushed. The work is committed and bookmarked locally.
