### PR TITLE
feat(nebius): provide /checkpoint as tmpfs and disable GPU dedup

### DIFF
--- a/cedana-helm/templates/configmap.yaml
+++ b/cedana-helm/templates/configmap.yaml
@@ -42,6 +42,9 @@ data:
   shm-config-enabled: "{{ .Values.hostConfig.shmConfig.enabled }}"
   shm-config-size: "{{ .Values.hostConfig.shmConfig.size }}"
   shm-config-min-size: "{{ .Values.hostConfig.shmConfig.minSize }}"
+  checkpoint-tmpfs-enabled: "{{ .Values.hostConfig.checkpointTmpfs.enabled }}"
+  checkpoint-tmpfs-size: "{{ .Values.hostConfig.checkpointTmpfs.size }}"
+  checkpoint-tmpfs-mode: "{{ .Values.hostConfig.checkpointTmpfs.mode }}"
 
   criu-log-level: "{{ .Values.config.criuLogLevel }}"
 {{- end }}

--- a/cedana-helm/templates/helper-daemonset.yaml
+++ b/cedana-helm/templates/helper-daemonset.yaml
@@ -288,6 +288,25 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cedana-helm.configMapName" . }}
                   key: shm-config-min-size
+            # /checkpoint as tmpfs: the memory storage tier for checkpoints.
+            # Off unless enabled, because tmpfs pages are charged to node memory
+            # and compete with the workload — a GPU worker here requests 48Gi and
+            # may limit at 80Gi on an ~85GiB node.
+            - name: CHECKPOINT_TMPFS_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: checkpoint-tmpfs-enabled
+            - name: CHECKPOINT_TMPFS_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: checkpoint-tmpfs-size
+            - name: CHECKPOINT_TMPFS_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "cedana-helm.configMapName" . }}
+                  key: checkpoint-tmpfs-mode
       volumes:
         - name: varlog
           hostPath:

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -26,7 +26,21 @@ config:
   # Baked into the helper image from the Cedana CI plugin registry, so this is
   # resolved locally like the others and never downloaded on the node.
   pluginsGpuVersion: v0.7.3
-  gpuDedupEnabled: true
+  # GPU dedup is off because it cannot work on this node, and with it on the
+  # checkpoint does not merely lose deduplication — it fails outright.
+  #
+  # Dedup JIT-compiles a chunk-hashing kernel through NVRTC and looks for
+  # libnvrtc.so.11.2, a CUDA 11 library. This node runs driver 580 / CUDA 13 and
+  # has no libnvrtc at all, so the first GPU dump failed with:
+  #
+  #   DedupKernel init failed: cannot dlopen libnvrtc.so for chunkHashKernel:
+  #     libnvrtc.so.11.2: cannot open shared object file
+  #   Failed to checkpoint worker: DedupKernel unavailable
+  #
+  # Freeze and unfreeze both succeeded and the model kept serving, so the failure
+  # is confined to capturing GPU state. Re-enable only with a matching libnvrtc
+  # present, and expect larger checkpoints without it.
+  gpuDedupEnabled: false
   gpuTemplatesEnabled: false
   gpuPoolSize: 0
   gpuShmSize: "8589934592"
@@ -56,7 +70,7 @@ daemonHelper:
     # plus criu, the containerd shim, and the runc/containerd .so files baked
     # into /opt/cedana/plugins.
     repository: cedana/cedana-helper
-    digest: sha256:ad8711b00ffb24bfd45cf4c9c199be6bc61dfb5b3fe0330fa5783b9ad0ecfa11
+    digest: sha256:b49791df1e9f99377698d7229b704bbe5cbb340e95146086ad2d3fdba0ee5008
   # Checkpoint/restore only ever runs on the L40S nodes, so the helper only runs
   # there. It rewrites kubelet config and installs a host service; keeping it off
   # the control nodes keeps the databases, propagator, and UI out of its blast
@@ -102,7 +116,7 @@ dynamoWatcher:
   inferenceNamespace: inference
   image:
     repository: cedana/cedana-dynamo-watcher
-    digest: sha256:722c8a8d4a43659731d283baf7e098828961cb52ec46491f866e4fa724ccba31
+    digest: sha256:c86646c13d22830b0fa13317dd202513c3820d4b55f6b3ff81f683d4d61e0814
   experiments:
     gpuNodeSelector:
       nebius.com/gpu-name: L40S

--- a/cedana-helm/values-nebius.yaml
+++ b/cedana-helm/values-nebius.yaml
@@ -31,6 +31,24 @@ config:
   gpuPoolSize: 0
   gpuShmSize: "8589934592"
 
+# /checkpoint as tmpfs on the GPU nodes — the "memory" tier for checkpoints.
+#
+# Enabled here because this is where checkpointed workloads run, and the helper
+# only runs on the L40S nodes anyway. Restoring from RAM is what avoids the eleven
+# minute cold weight load measured on this hardware; the trade is that the
+# checkpoint dies with the node, so it serves model swaps on a live node and not
+# recovery from node loss.
+#
+# 50G against ~85GiB of host RAM. A 27B FP8 checkpoint is ~30GB, so this holds one
+# with headroom. It cannot go much higher: the GPU worker requests 48Gi and may
+# limit at 80Gi, and tmpfs pages are charged to the same node memory — the setup
+# script refuses anything above 80% of RAM rather than quietly shrinking it.
+hostConfig:
+  checkpointTmpfs:
+    enabled: true
+    size: 50G
+    mode: "1777"
+
 daemonHelper:
   enabled: true
   image:
@@ -45,6 +63,22 @@ daemonHelper:
   # radius. With the GPU group scaled to 0 this DaemonSet has no nodes at all.
   nodeSelector:
     nebius.com/gpu-name: L40S
+  # Wait for gpu-operator to finish before the helper runs at all. Tolerating
+  # the not-ready taint only lets gpu-operator *start* first — both DaemonSets
+  # would otherwise schedule together and the helper could win the race, set up
+  # the node with no driver present, and leave its GPU plugin blind until
+  # something restarted it.
+  #
+  # nvidia.com/cuda.driver-version.full is published by the operator's
+  # feature-discovery only once a driver is installed and working, so requiring
+  # it makes "driver ready" a scheduling precondition rather than a poll.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: nvidia.com/cuda.driver-version.full
+                operator: Exists
   tolerations:
     - key: "cedana.ai/not-ready"
       operator: "Exists"
@@ -68,7 +102,7 @@ dynamoWatcher:
   inferenceNamespace: inference
   image:
     repository: cedana/cedana-dynamo-watcher
-    digest: sha256:2306bd73eeffcaf65f93d8d8f0641768c9ae95bfb9ac7e67a27b8543c6dc2310
+    digest: sha256:722c8a8d4a43659731d283baf7e098828961cb52ec46491f866e4fa724ccba31
   experiments:
     gpuNodeSelector:
       nebius.com/gpu-name: L40S

--- a/cedana-helm/values.yaml
+++ b/cedana-helm/values.yaml
@@ -90,6 +90,22 @@ hostConfig:
     enabled: false # Set to true to enable /dev/shm size increase
     size: 10G # Size to set for /dev/shm (e.g., "10G", "20G")
     minSize: 10G # Minimum size to trigger remount (e.g., "10G", "20G")
+  # /checkpoint as tmpfs — the "memory" storage tier for Cedana checkpoints.
+  #
+  # Restoring from RAM is what avoids a cold weight load, which measures eleven
+  # minutes from block storage for a 27B FP8 model. The trade is that a tmpfs
+  # checkpoint dies with the node, so this tier serves model swaps on a live node
+  # and cannot serve recovery from node loss.
+  #
+  # Off by default: tmpfs pages are charged to node memory and compete with the
+  # workload, so only enable it on nodes that actually host checkpointed
+  # workloads. The setup script refuses a size above 80% of host RAM rather than
+  # clamping it, because a silently smaller mount surfaces as a checkpoint failing
+  # part-written.
+  checkpointTmpfs:
+    enabled: false
+    size: 50G # Must hold a full checkpoint; a 27B FP8 model is ~30GB
+    mode: "1777" # Written by the shim, possibly read by a differently-owned restore
 
 daemonHelper:
   # Deploy the helper DaemonSets (and the health-check DaemonSet). Set false


### PR DESCRIPTION
## What

- Provides `/checkpoint` as tmpfs on the GPU nodes — the memory storage tier
  writes there, and it has to be memory-backed for a 42 GiB dump to complete in
  ~30 s.
- Disables GPU dedup, which fails the checkpoint outright on CUDA 13.

## Why

The memory tier is what makes the headline number possible: 42 GiB of CRIU + GPU
state in about 30 seconds, with the model still serving. Backing `/checkpoint`
with a disk volume instead loses that, and GPU dedup turns a working checkpoint
into a failed one on this driver stack.

Both of these are node-level facts about this cluster, which is why they live in
the Nebius values rather than in the controller.

## Stacking

Base is `swarnim/nebius-inference-stack` (PR 2 of 3 in this repo's stack).

## Depends on

- **cedana `swarnim/k8s-checkpoint-tmpfs`** — the helper-side change that actually
  provides `/checkpoint` as tmpfs for the memory storage tier. This chart
  configures it; that PR implements it.
- **cedana-controller `swarnim/dynamo-checkpoint-restore`** — the consumer.
